### PR TITLE
Build deterministic ISO in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# The following information is from https://hub.docker.com/r/nixos/nix/tags
+FROM nixos/nix:2.3.11@sha256:6903aa8484f625a304961ef9166ea89954421888f6a59af09893b17630225710 as image_builder
+
+#########################################################
+# Step 1: Prepare nixpkgs for deterministic builds
+#########################################################
+WORKDIR /build
+# Note that this commit is tagged as 20.09 in nixpkgs
+ENV NIXPKGS_COMMIT_SHA="cd63096d6d887d689543a0b97743d28995bc9bc3"
+
+# Necessary patch for deterministic ISO build. This provides a workaround
+# until https://github.com/NixOS/nixpkgs/pull/119657 is included in a stable
+# nixpkgs release
+COPY nixpkgs.patch /build/nixpkgs.patch
+
+RUN nix-env -i git && \
+    mkdir -p /build/nixpkgs && \
+    cd nixpkgs && \
+    git init && \
+    git remote add origin https://github.com/NixOS/nixpkgs.git && \
+    git fetch --depth 1 origin ${NIXPKGS_COMMIT_SHA} && \
+    git checkout FETCH_HEAD && \
+    git apply ../nixpkgs.patch && \
+    cd ../
+
+ENV NIX_PATH=nixpkgs=/build/nixpkgs
+
+#########################################################
+# Step 2: Build docker image
+#########################################################
+COPY pkgs/ /build/pkgs
+COPY custom_configuration.nix /build/custom_configuration.nix
+COPY iso.nix /build/iso.nix
+
+# Build final artifact
+RUN nix-build iso.nix

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+all: docker
+
+iso:
+	$(mkfile_dir)/build_iso.sh 2>/dev/null
+
+clean:
+	rm -rf $(mkfile_dir)/out

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ $ sha256sum $(readlink -f result)/iso/nixos-21.05pre-git-x86_64-linux.iso
 10b295f5126f990133cd97879d59c75354a8b86c912c77d0475c9c3ce8287ef8  /nix/store/avs706g4s16c7x0m3c2z99ix6l6v1l6a-nixos-21.05pre-git-x86_64-linux.iso/iso/nixos-21.05pre-git-x86_64-linux.iso
 ```
 
+## Build ISO in Docker
+
+The above deterministic ISO creation process can be automated using Docker.
+Run the following command in the repository root directory.
+
+```bash
+make iso
+```
+
+When we make the ISO at revision
+`115dc680cffbe9f358c6ad2b486f1c725addbdf8`, text like that shown below
+is expected in command output. The value for `IMAGE sha256sum` is
+critical to check for reproducibility.
+
+```text
+============ CUSTOM NIXOS ISO INFO ============
+ISO image created in /home/syncom/Development/custom_nixos_iso/out/custom_nixos_iso-115dc680cffbe9f358c6ad2b486f1c725addbdf8.iso
+IMAGE sha256sum: c38694f9284d1436b68f11ea9d1a4ba319544af715a81f5ace419cf0129fd134
+```
+
 ## References
 
 I've learned from the following resources:

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OUT_DIR="${SCRIPT_DIR}/out"
+REVISION=$(git --work-tree="${SCRIPT_DIR}/" \
+  --git-dir="${SCRIPT_DIR}/.git" \
+  rev-parse HEAD)
+IN_ISO_NAME="nixos-20.09pre-git-x86_64-linux.iso"
+OUT_ISO_NAME="custom_nixos_iso-${REVISION}.iso"
+BUILDER_TAG_NAME="nixos-builder:$REVISION"
+
+echo "Building custom ISO image"
+cd "${SCRIPT_DIR}"
+docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
+docker images "${BUILDER_TAG_NAME}"
+mkdir -p "${OUT_DIR}"
+
+docker run --entrypoint=/bin/sh --rm -i -v "${OUT_DIR}":/tmp/ \
+  "${BUILDER_TAG_NAME}" << CMD
+cp -Lr "/build/result/iso/${IN_ISO_NAME}" "/tmp/${OUT_ISO_NAME}"
+CMD
+
+echo
+echo "============ CUSTOM NIXOS ISO INFO ============"
+echo "ISO image created in ${OUT_DIR}/${OUT_ISO_NAME}"
+echo -n "IMAGE sha256sum: "
+sha256sum "${OUT_DIR}/${OUT_ISO_NAME}" | cut -f1 -d' '
+echo

--- a/nixpkgs.patch
+++ b/nixpkgs.patch
@@ -1,0 +1,19 @@
+diff --git a/nixos/modules/installer/cd-dvd/iso-image.nix b/nixos/modules/installer/cd-dvd/iso-image.nix
+index 405fbfa10db..49c90da6a13 100644
+--- a/nixos/modules/installer/cd-dvd/iso-image.nix
++++ b/nixos/modules/installer/cd-dvd/iso-image.nix
+@@ -371,7 +371,13 @@ let
+       echo "Image size: $image_size"
+       truncate --size=$image_size "$out"
+       ${pkgs.libfaketime}/bin/faketime "2000-01-01 00:00:00" ${pkgs.dosfstools}/sbin/mkfs.vfat -i 12345678 -n EFIBOOT "$out"
+-      mcopy -psvm -i "$out" ./EFI ./boot ::
++      echo "[Debug] sha256sum $out: `sha256sum $out`"
++#      mcopy -psvm -i "$out" ./EFI ./boot ::
++      for d in $(find EFI -type d | sort); do echo "$d"; ${pkgs.libfaketime}/bin/faketime "2000-01-01 00:00:00" ${pkgs.mtools}/bin/mmd -i "$out" "::/$d"; done
++      for d in $(find boot -type d | sort); do echo "$d"; ${pkgs.libfaketime}/bin/faketime "2000-01-01 00:00:00" ${pkgs.mtools}/bin/mmd -i "$out" "::/$d"; done
++      for f in $(find EFI -type f | sort); do echo "$f"; ${pkgs.mtools}/bin/mcopy -pvm -i "$out" "$f" "::/$f"; done
++      for f in $(find boot -type f | sort); do echo "$f"; ${pkgs.mtools}/bin/mcopy -pvm -i "$out" "$f" "::/$f"; done
++      echo "[Debug] sha256sum $out: `sha256sum $out`"
+       # Verify the FAT partition.
+       ${pkgs.dosfstools}/sbin/fsck.vfat -vn "$out"
+     ''; # */


### PR DESCRIPTION
We make the ISO building process a 1-click.
To build the ISO, run `make iso`.