### PR TITLE
Relax system

### DIFF
--- a/iso.nix
+++ b/iso.nix
@@ -1,4 +1,4 @@
-{nixpkgs ? <nixpkgs>, system ? "x86_64-linux"}:
+{nixpkgs ? <nixpkgs>, system ? builtins.currentSystem}:
 
 let 
 hello_syncom = (import ./custom_configuration.nix {}).hello_syncom;


### PR DESCRIPTION
Relax the `system` value so that nix-build can also work on non `x86_64-linux` systems. The other systems are not tested.