### PR TITLE
Use nixpkgs 23.05 in Dockerfile

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -18,11 +18,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v2
-      #- name: "Install Docker"
-      #  if: ${{ matrix.os == 'macos-latest' }}
-      #  # 1.0.11
-      #  uses: docker-practice/actions-setup-docker@5d9a5f65f510c01ec5f0bd81d5c95768b1ec032a
       - name: "Build ISO image"
         run: |
+          set -euxo pipefail
           cd ${{ github.workspace }}
           ./build_iso.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ FROM nixos/nix:2.9.0@sha256:13b257cd42db29dc851f9818ea1bc2f9c7128c51fdf000971fa6
 # Step 1: Prepare nixpkgs for deterministic builds
 #########################################################
 WORKDIR /build
-# Note that this commit is tagged as 21.11 in nixpkgs, which
+# Note that this commit is tagged as 23.05 in nixpkgs, which
 # includes the determinism improvement
 # https://github.com/NixOS/nixpkgs/pull/119657
-ENV NIXPKGS_COMMIT_SHA="a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31"
+ENV NIXPKGS_COMMIT_SHA="4ecab3273592f27479a583fb6d975d4aba3486fe"
 
 # Apple M1 workaround
 COPY nix.conf /build/nix.conf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Example of deterministic custom nixOS ISO build
+# Recipe for deterministic custom nixOS ISO builds
 
-Build custom nixOS ISO
+Build custom nixOS ISO (the ISO is "custom" in that it contains a custom package
+named "hello_syncom")
 
 ```bash
 curl -L https://nixos.org/nix/install | sh

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -7,7 +7,7 @@ OUT_DIR="${SCRIPT_DIR}/out"
 REVISION=$(git --work-tree="${SCRIPT_DIR}/" \
   --git-dir="${SCRIPT_DIR}/.git" \
   rev-parse HEAD)
-IN_ISO_NAME="nixos-21.11pre-git-x86_64-linux.iso"
+IN_ISO_NAME="nixos-23.05pre-git-x86_64-linux.iso"
 OUT_ISO_NAME="custom_nixos_iso-${REVISION}.iso"
 BUILDER_TAG_NAME="nixos-builder:$REVISION"
 


### PR DESCRIPTION
Now that 23.05 has been released, we use this version in the Dockerfile.

Also prune README.md and build-iso.yml