### PR TITLE
GHA: upgrade actions/checkout to v4.1.1

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - name: "Build ISO image"
         run: |
           set -euxo pipefail

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Install shellcheck on Ubuntu
         run: |


### PR DESCRIPTION
Upgrade actions/checkout to move away from the deprecated node 12.